### PR TITLE
Check interaction options to disable/enable selections and tooltip

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -9,8 +9,8 @@ function setupPaint({ $, qlik }) {
   return function ($element, layout) {
     // Call irregularUtils to page the data for > 10000 points
     const maxPages = this.inAnalysisState() ? 10 : 1;
-    const enableTooltips = this.options.tooltips;
-    const enableSelections = this.options.selections;
+    const enableTooltips = this.options.tooltips !== false && this.inAnalysisState();
+    const enableSelections = this.options.selections !== false && this.inAnalysisState();
 
     pageExtensionData(this, $element, layout, heatMap, maxPages);
 

--- a/src/paint.js
+++ b/src/paint.js
@@ -8,9 +8,10 @@ function setupPaint({ $, qlik }) {
 
   return function ($element, layout) {
     // Call irregularUtils to page the data for > 10000 points
-    const maxPages = this.inAnalysisState() ? 10 : 1;
-    const enableTooltips = this.options.tooltips !== false && this.inAnalysisState();
-    const enableSelections = this.options.selections !== false && this.inAnalysisState();
+    const inAnalysisState = this.inAnalysisState();
+    const maxPages = inAnalysisState ? 10 : 1;
+    const enableTooltips = this.options.tooltips !== false && inAnalysisState;
+    const enableSelections = this.options.selections !== false && inAnalysisState;
 
     pageExtensionData(this, $element, layout, heatMap, maxPages);
 
@@ -127,7 +128,7 @@ function setupPaint({ $, qlik }) {
         }).css({
           height: height,
           width: width,
-          overflow: !_this.inAnalysisState() ? "hidden" : "auto"
+          overflow: !inAnalysisState ? "hidden" : "auto"
         }));
       }
 
@@ -310,7 +311,7 @@ function setupPaint({ $, qlik }) {
         var svg = d3.select("#" + id).append("svg:svg")
           .attr("height", (showLegend ? 50 : 20) + dim2RotationOffset + (dim1keys.length * gridSize))
           .style("overflow","visible")
-          .classed('in-edit-mode', !_this.inAnalysisState());
+          .classed('in-edit-mode', !inAnalysisState);
 
         var svg_g = svg.append("g")
           .attr("transform", "translate(" + margin.left + "," + margin.top + ")");

--- a/src/paint.js
+++ b/src/paint.js
@@ -8,7 +8,10 @@ function setupPaint({ $, qlik }) {
 
   return function ($element, layout) {
     // Call irregularUtils to page the data for > 10000 points
-    const maxPages = qlik.navigation.getMode() === "analysis" ? 10 : 1;
+    const maxPages = this.inAnalysisState() ? 10 : 1;
+    const enableTooltips = this.options.tooltips;
+    const enableSelections = this.options.selections;
+
     pageExtensionData(this, $element, layout, heatMap, maxPages);
 
     function heatMap($element, layout, fullMatrix, _this) {
@@ -124,7 +127,7 @@ function setupPaint({ $, qlik }) {
         }).css({
           height: height,
           width: width,
-          overflow: _this.inEditState() ? "hidden" : "auto"
+          overflow: !_this.inAnalysisState() ? "hidden" : "auto"
         }));
       }
 
@@ -307,7 +310,7 @@ function setupPaint({ $, qlik }) {
         var svg = d3.select("#" + id).append("svg:svg")
           .attr("height", (showLegend ? 50 : 20) + dim2RotationOffset + (dim1keys.length * gridSize))
           .style("overflow","visible")
-          .classed('in-edit-mode',_this.inEditState());
+          .classed('in-edit-mode', !_this.inAnalysisState());
 
         var svg_g = svg.append("g")
           .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
@@ -402,7 +405,7 @@ function setupPaint({ $, qlik }) {
         var dim1Click = function (d, i) {};
         var dim2Click = function (d, i) {};
         var tileClick = function (d, i) {};
-        if (qlik.navigation.getMode() === "analysis") {
+        if (enableSelections) {
           dim1Click = function (d, i) {
             if (dim1Elements[i] >= 0)
               _this.backendApi.selectValues(0, [dim1Elements[i]], true);
@@ -547,7 +550,7 @@ function setupPaint({ $, qlik }) {
                 "borderedHover": false
               });
           });
-        if(!_this.inEditState()){
+        if(enableTooltips){
           heat.append("title").text(titleText);
         }
 
@@ -639,14 +642,14 @@ function setupPaint({ $, qlik }) {
               });
           }
 
-          if(!_this.inEditState()){
+          if(enableTooltips){
             legend.append("title").text(function (d) {
               return (gridSize < smallSize ? "" : "≥ ") + (measurePercentage ? formatLegend(Math.round(d * 1000) / 10) + "%" : formatLegend(d > 1 ? Math.round(d) : d));
             });
           }
         }
 
-        if (qlik.navigation.getMode() === "analysis") {
+        if (enableSelections) {
           // Create the area where the lasso event can be triggered
           var lasso_area = svg_g_lasso;
 


### PR DESCRIPTION
We hit a bug on our side when implementing an related feature, which overlaps with fixes for storytelling.
These changes should make the chart behave correctly in the various storytelling and sheet scenarios and similar solutions can be applied to other charts.