### PR TITLE
fix:QB-374 disabling right click to limiting the result set for export in heat map chart

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -329,7 +329,6 @@ function setupPaint({ $, qlik }) {
         var lasso_start = function () {
           // keep mouse cursor arrow instead of text select (auto)
           $("#" + id).css('cursor', 'default');
-
           // clear all of the fills
           lasso.items()
             .classed({
@@ -370,6 +369,10 @@ function setupPaint({ $, qlik }) {
         };
 
         var lasso_end = function (data) {
+          // disable selection from mouse right click
+          if(event && event.button === 2){
+            return false;
+          }
           var selectedItems = lasso.items().filter(function (d) {
             return d.selected === true;
           });


### PR DESCRIPTION
Issue :: 
[QB-374](https://jira.qlikdev.com/browse/QB-374)
File Changed ::  
src/paint.js
package.json
Code Changes ::  
*limiting right click to make heat map chart selection by using mouse right button code
*changed version

